### PR TITLE
[Fix] KAN-53 학교 정보 입력 수정

### DIFF
--- a/src/components/common/SchoolSelector.jsx
+++ b/src/components/common/SchoolSelector.jsx
@@ -49,7 +49,14 @@ const SchoolSelector = ({ schoolData, onSchoolChange }) => {
             majorName: schoolData.majorName || "일반과정", // 학과가 없는 학교(초, 중) 기본값
           },
         });
-        setClassList(res.data.map(c => c.CLASS_NM));
+                // 1. API 응답(res.data)에서 반 이름(CLASS_NM)만 추출하여 새 배열 생성
+        const classNames = res.data.map(c => c.CLASS_NM);
+
+        // 2. 추출된 배열을 숫자 기준으로 오름차순 정렬
+        const sortedClasses = classNames.sort((a, b) => Number(a) - Number(b));
+
+        // 3. 올바르게 정렬된 배열을 상태(state)에 저장
+        setClassList(sortedClasses);
       } catch (error) { console.error("반 조회 실패:", error); }
     };
     fetchClasses();


### PR DESCRIPTION
문제 현상
회원가입의 '학교 정보 입력' 단계에서 학년 선택 후 '반'을 선택하려고 할 때, 드롭다운 목록이 숫자 순서대로 정렬되지 않는 문제가 발생.
(예시) 1반, 10반, 11반, 2반, 3반... 과 같이 비정상적인 순서로 표시됨.

해결 방안
파일: SchoolSelector.jsx
조치 내용: API를 통해 반 목록 데이터를 받아온 직후, 화면에 표시하기 전에 숫자(Number) 기준 오름차순 정렬 로직을 추가.