### PR TITLE
[Feat] KAN-51 ScheduleTabmenu 추가 후 출석현황 연결

### DIFF
--- a/src/components/calendar/AttendanceCalendar.jsx
+++ b/src/components/calendar/AttendanceCalendar.jsx
@@ -1,16 +1,8 @@
-// AttendanceCalendar.jsx
 import React, { useState, useEffect, useCallback } from "react";
 import styled from "styled-components";
 import axios from "axios";
 import AttemdImg from "@/assets/images/attend.png";
-import {
-  FaChevronLeft,
-  FaChevronRight,
-  FaStar,
-  FaUser,
-  FaListAlt,
-  FaCalendarAlt,
-} from "react-icons/fa";
+import { FaChevronLeft, FaChevronRight, FaArrowLeft } from "react-icons/fa";
 
 const BASE_API_URL =
   import.meta.env.VITE_API_URL || "http://localhost:9000/api";
@@ -51,7 +43,7 @@ const getCalendarInfo = (year, month) => {
   return { firstDay, totalDays };
 };
 
-const AttendanceCalendar = () => {
+const AttendanceCalendar = ({ onGoBack }) => {
   // viewDate 상태: 사용자가 현재 보고 있는 달력의 년/월을 관리
   const [viewDate, setViewDate] = useState({
     year: CURRENT_YEAR,
@@ -133,6 +125,10 @@ const AttendanceCalendar = () => {
 
   return (
     <CalendarContainer>
+      <BackButton onClick={onGoBack}>
+        {" "}
+        <FaArrowLeft size={20} />
+      </BackButton>
       <CalendarSection>
         <SubHeader>
           <AttendanceInfo>
@@ -207,6 +203,25 @@ const CalendarContainer = styled.div`
   max-width: 1200px;
   margin: 186px auto 0;
   font-family: "Malgun Gothic", "Apple SD Gothic Neo", sans-serif;
+`;
+
+const BackButton = styled.button`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  background: none;
+  border: none;
+  color: #3f51b5;
+  font-size: 16px;
+  font-weight: 600;
+  cursor: pointer;
+  margin-bottom: 20px;
+  padding: 10px 0;
+  transition: opacity 0.2s;
+
+  &:hover {
+    opacity: 0.8;
+  }
 `;
 
 const CalendarSection = styled.div`

--- a/src/components/schedule/ScheduleTabmenu.jsx
+++ b/src/components/schedule/ScheduleTabmenu.jsx
@@ -1,0 +1,102 @@
+import React from "react";
+import styled, { css } from "styled-components";
+
+// 이미지 분석 기반 탭 이름
+const TABS = [
+  { id: "meal", label: "식단" },
+  { id: "schedule", label: "학사 일정" },
+  { id: "timetable", label: "수업 시간표" },
+];
+
+const TabMenu = ({ activeTab, onTabSelect, onViewAttendance }) => {
+  return (
+    <TabMenuContainer>
+      <TabList>
+        {TABS.map((tab) => (
+          <Tab
+            key={tab.id}
+            $active={activeTab === tab.id}
+            onClick={() => onTabSelect(tab.id)}
+          >
+            {tab.label}
+          </Tab>
+        ))}
+      </TabList>
+
+      <AttendanceSection>
+        <AttendanceText>출석 현황이 궁금하다면?</AttendanceText>
+        <AttendanceButton onClick={onViewAttendance}>보러가기</AttendanceButton>
+      </AttendanceSection>
+    </TabMenuContainer>
+  );
+};
+
+export default TabMenu;
+
+const SECONDARY_COLOR = "#fccb48";
+
+const TabMenuContainer = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin: 80px 0 60px 0;
+  width: 100%;
+  max-width: 1200px;
+  box-sizing: border-box;
+`;
+
+const TabList = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 12px;
+`;
+
+const Tab = styled.button`
+  background-color: #fff;
+  color: #555;
+  border: 1px solid #e0e0e0;
+  border-radius: 30px;
+  font-size: 1rem;
+  font-weight: 500;
+  width: 146px;
+  height: 40px;
+  cursor: pointer;
+  transition: all 0.2s;
+
+  ${(props) =>
+    props.$active &&
+    css`
+      background-color: ${SECONDARY_COLOR};
+      color: #333;
+      border: none;
+    `}
+`;
+
+const AttendanceSection = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 10px;
+`;
+
+const AttendanceText = styled.p`
+  font-size: 1rem;
+  font-size: 1rem;
+  font-weight: 500;
+  color: #333;
+  margin: 0;
+  padding-top: 5px;
+`;
+
+const AttendanceButton = styled.button`
+  background-color: #d9d9d9;
+  color: #333;
+  border: none;
+  border-radius: 8px;
+  padding: 10px 20px;
+  font-size: 1rem;
+  font-weight: 500;
+  width: 106px;
+  transition: background-color 0.2s;
+  cursor: pointer;
+`;

--- a/src/pages/Schedule.jsx
+++ b/src/pages/Schedule.jsx
@@ -1,9 +1,95 @@
-import React from "react";
+import React, { useRef, useState, useCallback } from "react";
 import styled from "styled-components";
 import MealSection from "@/components/mainpage/MealSection";
 import SchoolSchedule from "@/components/schedule/SchoolSchedule";
 import SchoolTimetable from "@/components/schedule/SchoolTimetable";
 import TopMenu from "@/components/mainpage/TopMenu";
+import ScheduleTabmenu from "../components/schedule/ScheduleTabmenu";
+import AttendanceCalendar from "../components/calendar/AttendanceCalendar";
+
+const Schedule = () => {
+  // 스크롤 대상 설정
+  const mealRef = useRef(null);
+  const schoolScheduleRef = useRef(null);
+  const schoolTimetableRef = useRef(null);
+
+  // 탭 상태 및 출석 뷰 상태 관리
+  const [activeTab, setActiveTab] = useState("meal");
+  const [showAttendance, setShowAttendance] = useState(false);
+
+  // 스크롤 핸들러
+  const handleTabSelect = useCallback((tabId) => {
+    setActiveTab(tabId);
+    let targetRef;
+
+    switch (tabId) {
+      case "meal":
+        targetRef = mealRef;
+        break;
+      case "schedule":
+        targetRef = schoolScheduleRef;
+        break;
+      case "timetable":
+        targetRef = schoolTimetableRef;
+        break;
+      default:
+        return;
+    }
+    if (targetRef.current) {
+      // 해당 영역으로 부드럽게 스크롤
+      targetRef.current.scrollIntoView({ behavior: "smooth", block: "start" });
+    }
+  }, []);
+
+  // 4. 출석 뷰 전환 핸들러
+  const handleViewAttendance = useCallback(() => {
+    setShowAttendance(true);
+  }, []);
+
+  const handleGoBack = useCallback(() => {
+    setShowAttendance(false);
+  }, []);
+
+  return (
+    <AppContainer>
+      <ContentWrapper>
+        <TopMenu />
+
+        {/* 출석 캘린더가 활성화된 경우 */}
+        {showAttendance ? (
+          <AttendanceCalendar onGoBack={handleGoBack} />
+        ) : (
+          // 기본 스케줄 뷰
+          <>
+            {/* ScheduleTabmenu 추가 및 핸들러 연결 */}
+            <ScheduleTabmenu
+              activeTab={activeTab}
+              onTabSelect={handleTabSelect}
+              onViewAttendance={handleViewAttendance}
+            />
+            <Separator />
+
+            {/* 각 영역에 ref 연결 */}
+            <div ref={mealRef}>
+              <MealSection />
+            </div>
+
+            <Separator />
+            <div ref={schoolScheduleRef}>
+              <SchoolSchedule />
+            </div>
+
+            <Separator />
+            <div ref={schoolTimetableRef}>
+              <SchoolTimetable />
+            </div>
+          </>
+        )}
+      </ContentWrapper>
+    </AppContainer>
+  );
+};
+export default Schedule;
 
 const AppContainer = styled.div`
   display: flex;
@@ -21,29 +107,3 @@ const ContentWrapper = styled.div`
 const Separator = styled.div`
   height: 40px;
 `;
-
-const PageTitle = styled.h1`
-  font-size: 2rem;
-  font-weight: 600;
-  margin-bottom: 40px;
-`;
-
-const Schedule = () => {
-  return (
-    <AppContainer>
-      <ContentWrapper>
-      <TopMenu />
-
-        <MealSection />
-
-        <Separator />
-        <SchoolSchedule />
-
-        <Separator />
-        <SchoolTimetable />
-       
-      </ContentWrapper>
-    </AppContainer>
-  )
-}
-export default Schedule


### PR DESCRIPTION
jira : KAN-51

# Todo
- [x] Schedule.jsx에 ScheduleTabMenu 추가 후 출석 현황 페이지 연결

# etc
- 각 영역에 ref 연결
- 해당 영역으로 부드럽게 스크롤 로직 추가
- ScheduleTabmenu 내 "보러가기" 버튼 클릭 시, 페이지의 모든 기존 콘텐츠(식단, 일정 등)를 숨기고 AttendanceCalendar 컴포넌트를 렌더링하도록 showAttendance 상태를 도입하여 관리
- AttendanceCalendar 컴포넌트에 onGoBack prop을 전달하여, 달력 뷰에서 "이전 화면으로 돌아가기" 기능(setShowAttendance(false))을 통해 메인 일정 뷰로 복귀할 수 있도록 구현